### PR TITLE
Update 02_CARNIVAL_preprocessing.R

### DIFF
--- a/TF_enrichment/TF_enrichment_analysis-main/code/02_CARNIVAL_preprocessing.R
+++ b/TF_enrichment/TF_enrichment_analysis-main/code/02_CARNIVAL_preprocessing.R
@@ -56,7 +56,7 @@ InputCarnival$source_genesymbol <-
 InputCarnival$target_genesymbol <-
     gsub("-","_",InputCarnival$target_genesymbol)
 
-bad_int <- which(duplicated(paste(InputCarnival[,1],InputCarnival[,3])))
+bad_int <- which(InputCarnival[,1]==InputCarnival[,3])
 
 if ( length(bad_int) == 0 ) {
     InputCarnival <- InputCarnival


### PR DESCRIPTION
In the previous version, bad_int adds non-duplicated InputCarnival[,1] and InputCarnival[,3] as duplicated.